### PR TITLE
Fix mtk2 driver for Gemini PDA

### DIFF
--- a/gril/grilrequest.c
+++ b/gril/grilrequest.c
@@ -1125,26 +1125,34 @@ void g_ril_request_set_initial_attach_apn(GRil *gril, const char *apn,
 	proto_str = ril_ofono_protocol_to_ril_string(proto);
 	parcel_w_string(rilp, proto_str);
 
+	g_ril_append_print_buf(gril, "(%s,%s", apn, proto_str);
+
+	if (vendor == OFONO_RIL_VENDOR_MTK2) {
+		/* roamingProtocol */
+		parcel_w_string(rilp, proto_str);
+		g_ril_append_print_buf(gril, "%s,%s", print_buf, proto_str);
+	}
+
 	parcel_w_int32(rilp, auth_type);
 	parcel_w_string(rilp, user);
 	parcel_w_string(rilp, passwd);
 
-	g_ril_append_print_buf(gril, "(%s,%s,%s,%s,%s", apn, proto_str,
+	g_ril_append_print_buf(gril, "%s,%s,%s,%s", print_buf,
 				ril_authtype_to_string(auth_type),
 				user, passwd);
 
-	if (vendor == OFONO_RIL_VENDOR_MTK || vendor == OFONO_RIL_VENDOR_MTK2) {
+	if (vendor == OFONO_RIL_VENDOR_MTK) {
 		parcel_w_string(rilp, mccmnc);
 		g_ril_append_print_buf(gril, "%s,%s", print_buf, mccmnc);
-		if (vendor == OFONO_RIL_VENDOR_MTK2) {
-			int can_handle_ims = 0;
+	} else if (vendor == OFONO_RIL_VENDOR_MTK2) {
+		int can_handle_ims = 0;
+		int num_str = 0;
 
-			parcel_w_int32(rilp, can_handle_ims);
-			/* dualApnPlmnList */
-			parcel_w_string(rilp, NULL);
-			g_ril_append_print_buf(gril, "%s,%d,(null)", print_buf,
-								can_handle_ims);
-		}
+		parcel_w_string(rilp, ""); /* operatorNumeric, should be empty? */
+		parcel_w_int32(rilp, can_handle_ims);
+		parcel_w_int32(rilp, num_str);  /* dualApnPlmnList */
+		g_ril_append_print_buf(gril, "%s,(null),%d,%d", print_buf,
+							can_handle_ims, num_str);
 	}
 
 	g_ril_append_print_buf(gril, "%s)", print_buf);


### PR DESCRIPTION
I create this PR to have discussion ground (issues aren't enabled here for some reason) for the changes needed to support telephony on Gemini PDA in UBPorts. It has MediaTek's Helio X25/X27 SoC (MT6797T/MT6797X).

As I understand from commit messages, mtk2 ofono driver was written for cancelled midori device with Helio X20 (MT6797) SoC, which is rather close, and currently is not used for any UBPorts device (please confirm if tablet uses env OFONO_RIL_DEVICE=mtk, not mtk2). If the point is true, the proposed changes won't break any existing device.

This is enough to have 3G data and messages, but I haven't investigated audio in calls yet. However, LTE would require implementing either [this hack](https://github.com/Deepflex/android_device_elephone_p9000/blob/master/ril/telephony/java/com/android/internal/telephony/MT6755.java#L244) from LineageOS or doing it similar way to Mer's ofono (https://git.merproject.org/mer-core/ofono/blob/master/ofono/drivers/ril/ril_vendor_mtk.c#L421).

The issue is that unsol event codes seem to differ between devices even with similar SoCs. For example, MTK_SET_ATTACH_APN request shows up as MTK2_RIL_UNSOL_IMS_DISABLE_START for Gemini, which is clearly wrong. If I just modify MTK2_RIL_* codes to match mine, this may break things for potential new MTK devices. Mer's ofono currently has structs for different variants: https://git.merproject.org/mer-core/ofono/blob/master/ofono/drivers/ril/ril_vendor_mtk.c#L97. I wonder if it would make sense to do something similar.

The reason I used mtk2 is that it's overly simpler and closer to current Mer's ofono MTK code, which is known to work for newer devices. mtk driver has lots of MediaTek-specific hacks, which are not needed anymore, and causes RIL to error on start.