### PR TITLE
gril: follow struct size change in data call list

### DIFF
--- a/gril/grilunsol.c
+++ b/gril/grilunsol.c
@@ -229,9 +229,9 @@ struct ril_data_call_list *g_ril_unsol_parse_data_call_list(GRil *gril,
 	struct ril_data_call *call;
 	struct parcel rilp;
 	struct ril_data_call_list *reply = NULL;
-	unsigned int active, cid, i, num_calls, retry, status;
+	unsigned int active, cid, i, num_calls, retry, status, mtu;
 	char *type = NULL, *ifname = NULL, *raw_addrs = NULL;
-	char *raw_dns = NULL, *raw_gws = NULL;
+	char *raw_dns = NULL, *raw_gws = NULL, *raw_pcscf = NULL;
 
 	DBG("");
 
@@ -281,16 +281,10 @@ struct ril_data_call_list *g_ril_unsol_parse_data_call_list(GRil *gril,
 		raw_dns = parcel_r_string(&rilp);
 		raw_gws = parcel_r_string(&rilp);
 
-		/* malformed check */
-		if (rilp.malformed) {
-			ofono_error("%s: malformed parcel received", __func__);
-			goto error;
-		}
-
 		g_ril_append_print_buf(gril,
 					"%s [status=%d,retry=%d,cid=%d,"
 					"active=%d,type=%s,ifname=%s,"
-					"address=%s,dns=%s,gateways=%s]",
+					"address=%s,dns=%s,gateways=%s",
 					print_buf,
 					status,
 					retry,
@@ -301,6 +295,35 @@ struct ril_data_call_list *g_ril_unsol_parse_data_call_list(GRil *gril,
 					raw_addrs,
 					raw_dns,
 					raw_gws);
+
+		/*
+		 * XXX: ril.h says this field is available since v9, but
+		 * Android 7.1's RIL.java starts reading this field since v10.
+		 */
+		if (reply->version >= 9) {
+			raw_pcscf = parcel_r_string(&rilp);
+			/*
+			 * TODO: what is "Proxy Call State Control Function"?
+			 * It seems to relate to IMS/VoLTE according to ril.h.
+			 */
+			g_ril_append_print_buf(gril, "%s,pcscf=%s",
+						print_buf, raw_pcscf);
+		}
+
+		if (reply->version >= 11) {
+			mtu = parcel_r_int32(&rilp);
+			/* TODO: what can we do with MTU? */
+			g_ril_append_print_buf(gril, "%s,mtu=%d",
+						print_buf, mtu);
+		}
+
+		g_ril_append_print_buf(gril, "%s]", print_buf);
+
+		/* malformed check */
+		if (rilp.malformed) {
+			ofono_error("%s: malformed parcel received", __func__);
+			goto error;
+		}
 
 		call = g_try_new0(struct ril_data_call, 1);
 		if (call == NULL) {
@@ -323,6 +346,7 @@ struct ril_data_call_list *g_ril_unsol_parse_data_call_list(GRil *gril,
 		g_free(raw_addrs);
 		g_free(raw_dns);
 		g_free(raw_gws);
+		g_free(raw_pcscf);
 
 		reply->calls =
 			g_slist_insert_sorted(reply->calls, call,
@@ -345,6 +369,7 @@ error:
 	g_free(raw_addrs);
 	g_free(raw_dns);
 	g_free(raw_gws);
+	g_free(raw_pcscf);
 	g_ril_unsol_free_data_call_list(reply);
 
 	return NULL;


### PR DESCRIPTION
There are changes in RIL's data call list response in version 9 (or 10)
and 11 of the response. This cause a problem when there are more than 1
entry in the list.

This commit checks the version field to find out if it needs to read the
extra field(s). This fixes the problem where the device can randomly
become unable to send or receive an MMS message.

Note that there's conflicting information between ril.h [1] and
RIL.java [2] about the availability of the pcscf field, which I choose
to follow ril.h.

[1] https://github.com/LineageOS/android_hardware_ril/blob/cm-14.1/include/telephony/ril.h#L489
[2] https://github.com/LineageOS/android_frameworks_opt_telephony/blob/cm-14.1/src/java/com/android/internal/telephony/RIL.java#L4024