### PR TITLE
emulator: don't return error after calling cb

### DIFF
--- a/src/emulator.c
+++ b/src/emulator.c
@@ -1930,24 +1930,20 @@ int ofono_emulator_start_codec_negotiation(struct ofono_emulator *em,
 
 	if (!em->bac_received || em->negotiated_codec > 0) {
 		/*
-		 * Report we're done even if we don't have done any
-		 * negotiation as the other side may have to clean up.
-		 */
-		cb(0, data);
-
-		/*
 		 * If we didn't received any +BAC during the SLC setup the
 		 * remote side doesn't support codec negotiation and we can
 		 * directly connect our card. Otherwise if we got +BAC and
 		 * already have a negotiated codec we can proceed here
 		 * without doing any negotiation again.
+		 *
+		 * Report success/error via the callback even if we have not
+		 * done any negotiation as the other side may have to clean up.
 		 */
 		err = ofono_handsfree_card_connect_sco(em->card);
-		if (err < 0) {
+		if (err < 0)
 			ofono_error("SCO connection failed");
-			return err;
-		}
 
+		cb(err, data);
 		return 0;
 	}
 


### PR DESCRIPTION
Returning error from a function with callback implies that the callback
will not be called. Commit 018272a6dd5c7d1ac2227018614d3473aad4df88
("emulator: fail when SCO connection setup fails") broke this assumption
by returning error from ofono_handsfree_card_connect_sco after the
callback is called with success. This created a double-free situation
in hfp_ag_bluez5.c where it frees its "cbd" both in the callback and
when the call itself fails.

This commit make the code always return success in this situation, and
instead return the success or error via the callback, which seems to be
the code's original intention. I'm not sure if calling callback before
returning from the function is OK, but if the original code works
correctly in non-error case, this should work correctly too.