### PR TITLE
Allow configuration of set_udub ril op

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ofono (1.21+ubports2) xenial; urgency=medium
+
+  * Add ril config parameter to set set_udub ril request
+
+ -- José Pekkarinen <jose.pekkarinen@foxhound.fi>  Sun, 17 Oct 2021 20:35:57 +0200
+
 ofono (1.21+ubports1) xenial; urgency=medium
 
   * Port SailfishOS ofono fork to UBPorts

--- a/ofono/drivers/ril/ril_plugin.c
+++ b/ofono/drivers/ril/ril_plugin.c
@@ -27,6 +27,7 @@
 #include "ril_vendor.h"
 #include "ril_devmon.h"
 #include "ril_log.h"
+#include "ril-constants.h"
 
 #include "ofono.h"
 #include "sailfish_manager.h"
@@ -102,6 +103,7 @@
 #define RILMODEM_DEFAULT_SLOT_FLAGS SAILFISH_SLOT_NO_FLAGS
 #define RILMODEM_DEFAULT_CELL_INFO_INTERVAL_SHORT_MS (2000) /* 2 sec */
 #define RILMODEM_DEFAULT_CELL_INFO_INTERVAL_LONG_MS  (30000) /* 30 sec */
+#define RILMODEM_DEFAULT_RIL_REQUEST_ON_SET_UDUB     RIL_REQUEST_UDUB
 
 /* RIL socket transport name and parameters */
 #define RIL_TRANSPORT_MODEM                 "modem"
@@ -162,6 +164,7 @@
 #define RILCONF_DEVMON                      "deviceStateTracking"
 #define RILCONF_CELL_INFO_INTERVAL_SHORT_MS "cellInfoIntervalShortMs"
 #define RILCONF_CELL_INFO_INTERVAL_LONG_MS  "cellInfoIntervalLongMs"
+#define RILCONF_RIL_REQUEST_ON_SET_UDUB     "rilRequestOnSetUdub"
 
 /* Modem error ids */
 #define RIL_ERROR_ID_RILD_RESTART           "rild-restart"
@@ -1238,6 +1241,8 @@ static ril_slot *ril_plugin_slot_new_take(char *transport,
 				RILMODEM_DEFAULT_CELL_INFO_INTERVAL_SHORT_MS;
 	config->cell_info_interval_long_ms =
 				RILMODEM_DEFAULT_CELL_INFO_INTERVAL_LONG_MS;
+	config->ril_request_on_set_udub =
+				RILMODEM_DEFAULT_RIL_REQUEST_ON_SET_UDUB;
 	slot->timeout = RILMODEM_DEFAULT_TIMEOUT;
 	slot->sim_flags = RILMODEM_DEFAULT_SIM_FLAGS;
 	slot->slot_flags = RILMODEM_DEFAULT_SLOT_FLAGS;
@@ -1763,6 +1768,14 @@ static ril_slot *ril_plugin_parse_config_group(GKeyFile *file,
 				&config->cell_info_interval_long_ms)) {
 		DBG("%s: " RILCONF_CELL_INFO_INTERVAL_LONG_MS " %d",
 				group, config->cell_info_interval_long_ms);
+	}
+
+	/* rilRequestOnSetUdub */
+	if (ril_config_get_integer(file, group,
+				RILCONF_RIL_REQUEST_ON_SET_UDUB,
+				&config->ril_request_on_set_udub)) {
+		DBG("%s: " RILCONF_RIL_REQUEST_ON_SET_UDUB " %d",
+				group, config->ril_request_on_set_udub);
 	}
 
 	/* Replace devmon with a new one with applied settings */

--- a/ofono/drivers/ril/ril_subscription.conf
+++ b/ofono/drivers/ril/ril_subscription.conf
@@ -365,3 +365,10 @@ socket=/dev/socket/rild
 # Default 30000
 #
 #cellInfoIntervalLongMs=30000
+
+# Configure the ril request originated in ril_voicecall_set_udub. Some
+# devices like the Volla phone halts the modem when asking if the user
+# is busy through this function. This produces that, if you cancel an
+# awaiting call because of an on going one, both calls will be hang up.
+#
+#rilRequestOnSetUdub=13

--- a/ofono/drivers/ril/ril_types.h
+++ b/ofono/drivers/ril/ril_types.h
@@ -81,6 +81,7 @@ struct ril_slot_config {
 	GUtilInts *remote_hangup_reasons;
 	int cell_info_interval_short_ms;
 	int cell_info_interval_long_ms;
+	int ril_request_on_set_udub;
 };
 
 #endif /* RIL_TYPES_H */

--- a/ofono/drivers/ril/ril_voicecall.c
+++ b/ofono/drivers/ril/ril_voicecall.c
@@ -15,6 +15,7 @@
 
 #include "ril_plugin.h"
 #include "ril_ecclist.h"
+#include "ril_types.h"
 #include "ril_util.h"
 #include "ril_log.h"
 
@@ -56,6 +57,7 @@ struct ril_voicecall {
 	gulong supp_svc_notification_id;
 	gulong ringback_tone_event_id;
 	gulong ecclist_change_id;
+	int ril_request_on_set_udub;
 };
 
 struct ril_voicecall_request_data {
@@ -851,8 +853,10 @@ static void ril_voicecall_release_all_active(struct ofono_voicecall *vc,
 static void ril_voicecall_set_udub(struct ofono_voicecall *vc,
 					ofono_voicecall_cb_t cb, void *data)
 {
+	struct ril_voicecall *vd = ril_voicecall_get_data(vc);
 	DBG("");
-	ril_voicecall_request(RIL_REQUEST_UDUB, vc, NULL, cb, data);
+	ril_voicecall_request(vd->ril_request_on_set_udub,
+						vc, NULL, cb, data);
 }
 
 static void ril_voicecall_enable_supp_svc(struct ril_voicecall *vd)
@@ -949,6 +953,9 @@ static int ril_voicecall_probe(struct ofono_voicecall *vc, unsigned int vendor,
 	vd->vc = vc;
 	if (modem->ecclist_file) {
 		vd->ecclist = ril_ecclist_new(modem->ecclist_file);
+	}
+	if (cfg->ril_request_on_set_udub) {
+		vd->ril_request_on_set_udub = cfg->ril_request_on_set_udub;
 	}
 	ril_voicecall_clear_dtmf_queue(vd);
 	ofono_voicecall_set_data(vc, vd);


### PR DESCRIPTION
In some devices, like the Volla phone, the
operation of set_udub to request whether the
user is busy or not, produces a halt of the modem
dropping any on going call if the operation
happens, like rejecting a new incoming call
while one is active. This patch allows to
set the operation to a regular hangup.

Signed-off-by: José Pekkarinen <jose.pekkarinen@foxhound.fi>