### PR TITLE
Allow adding and removing APNs on android9

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -13,7 +13,6 @@ CONFIGURE_FLAGS := \
     --enable-sailfish-bt \
     --enable-sailfish-manager \
     --enable-sailfish-provision \
-    --enable-sailfish-pushforwarder \
     --enable-sailfish-rilmodem \
     --disable-add-remove-context \
     --disable-isimodem \

--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,6 @@ CONFIGURE_FLAGS := \
     --enable-sailfish-manager \
     --enable-sailfish-provision \
     --enable-sailfish-rilmodem \
-    --disable-add-remove-context \
     --disable-isimodem \
     --disable-qmimodem \
     --with-systemdunitdir=/lib/systemd/system


### PR DESCRIPTION
This change disables two build-time flags:
- Allow adding and removing APNs
- Disable a SailfishOS-only feature which we don't use (forwarding MMS to the so-called MMS Engine)

This branch has been tested by a few users in the US who need to adapt their APNs.